### PR TITLE
Amend workflow now that docdeps is going away

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,3 +1,5 @@
+# TODO!!! Use release branch of Firedrake when building
+
 name: Build and push website
 
 on:
@@ -20,38 +22,55 @@ jobs:
   build_website:
     name: Run doc build
     runs-on: ubuntu-latest
-    container:
-      image: firedrakeproject/firedrake-docdeps:latest
-    outputs:
-      conclusion: ${{ steps.report.outputs.conclusion }}
     steps:
       - uses: actions/checkout@v4
         with:
           path: firedrake-repo
           repository: firedrakeproject/firedrake
 
-      - name: Install Firedrake
-        id: install
+      - name: Install system dependencies
         run: |
-          python3 -m pip uninstall --break-system-packages -y firedrake
-          : # Pass '--system-site-packages' so already installed packages can be found
-          python3 -m venv --system-site-packages venv
+          apt-get update
+          apt-get -y install python3
+          apt-get -y install \
+            $(python3 ./firedrake-repo/scripts/firedrake-configure \
+              --arch ${{ matrix.arch }} --show-system-packages) \
+            python3-venv
+
+      - name: Install PETSc
+        run: |
+          git clone --depth 1 \
+            --branch $(python3 ./firedrake-repo/scripts/firedrake-configure --show-petsc-version) \
+            https://gitlab.com/petsc/petsc.git
+          cd petsc
+          python3 ../firedrake-repo/scripts/firedrake-configure \
+            --arch ${{ matrix.arch }} --show-petsc-configure-options | \
+            xargs -L1 ./configure --download-slepc
+          make PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc PETSC_ARCH=arch-firedrake-${{ matrix.arch }}
+          make check
+          {
+            echo "PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc"
+            echo "PETSC_ARCH=arch-firedrake-${{ matrix.arch }}"
+            echo "SLEPC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc/arch-firedrake-${{ matrix.arch }}"
+          } >> "$GITHUB_ENV"
+
+      - name: Install Firedrake
+        run: |
+          export $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-env)
+          python3 -m venv venv
           . venv/bin/activate
-          pip install --verbose './firedrake-repo[docs]'
+          pip install --verbose \
+            --no-binary h5py \
+            --extra-index-url https://download.pytorch.org/whl/cpu \
+            './firedrake-repo[docs]'
+          pip list
 
       - name: Check bibtex
         run: |
           . venv/bin/activate
           make -C firedrake-repo/docs validate-bibtex
 
-      - name: Check documentation links
-        run: |
-          . venv/bin/activate
-          make -C firedrake-repo/docs linkcheck
-
       - name: Build docs
-        id: build
-        if: success() || steps.install.conclusion == 'success'
         run: |
           . venv/bin/activate
           cd firedrake-repo/docs
@@ -61,31 +80,23 @@ jobs:
 
       - name: Copy manual to HTML tree
         id: copy
-        if: success() || steps.build.conclusion == 'success'
         run: |
           cd firedrake-repo/docs
           cp build/latex/Firedrake.pdf build/html/_static/manual.pdf
 
       - name: Upload artifact
         id: upload
-        if: success() || steps.copy.conclusion == 'success'
         uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages
-          path: /__w/firedrakeproject.github.io/firedrakeproject.github.io/firedrake-repo/docs/build/html
+          path: ./firedrake-repo/docs/build/html
           retention-days: 1
-      
-      - name: Report status
-        id: report
-        if: success() || steps.upload.conclusion == 'success'
-        run: echo "conclusion=success" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Deploy Github pages
     needs: build_website
     runs-on: ubuntu-latest
-    # Always run this workflow on main, even if linkcheck fails
-    if: always() && github.ref == 'refs/heads/main' && needs.build_website.outputs.conclusion == 'success'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get -y install python3
           sudo apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure \
-              --arch ${{ matrix.arch }} --show-system-packages) \
+              --arch default --show-system-packages) \
             python3-venv
 
       - name: Install PETSc
@@ -44,19 +44,19 @@ jobs:
             https://gitlab.com/petsc/petsc.git
           cd petsc
           python3 ../firedrake-repo/scripts/firedrake-configure \
-            --arch ${{ matrix.arch }} --show-petsc-configure-options | \
+            --arch default --show-petsc-configure-options | \
             xargs -L1 ./configure --download-slepc
-          make PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc PETSC_ARCH=arch-firedrake-${{ matrix.arch }}
+          make PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc PETSC_ARCH=arch-firedrake-default
           make check
           {
             echo "PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc"
-            echo "PETSC_ARCH=arch-firedrake-${{ matrix.arch }}"
-            echo "SLEPC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc/arch-firedrake-${{ matrix.arch }}"
+            echo "PETSC_ARCH=arch-firedrake-default"
+            echo "SLEPC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc/arch-firedrake-default"
           } >> "$GITHUB_ENV"
 
       - name: Install Firedrake
         run: |
-          export $(python3 ./firedrake-repo/scripts/firedrake-configure --arch ${{ matrix.arch }} --show-env)
+          export $(python3 ./firedrake-repo/scripts/firedrake-configure --arch default --show-env)
           python3 -m venv venv
           . venv/bin/activate
           pip install --verbose \
@@ -109,6 +109,7 @@ jobs:
 
   keepalive:
     name: Keepalive
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure \
               --arch default --show-system-packages) \
-            python3-venv
+            inkscape texlive-full python3-venv
 
       - name: Install PETSc
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           path: firedrake-repo
           repository: firedrakeproject/firedrake
+          ref: release
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,9 +30,9 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          apt-get update
-          apt-get -y install python3
-          apt-get -y install \
+          sudo apt-get update
+          sudo apt-get -y install python3
+          sudo apt-get -y install \
             $(python3 ./firedrake-repo/scripts/firedrake-configure \
               --arch ${{ matrix.arch }} --show-system-packages) \
             python3-venv

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -46,12 +46,12 @@ jobs:
           python3 ../firedrake-repo/scripts/firedrake-configure \
             --arch default --show-petsc-configure-options | \
             xargs -L1 ./configure --download-slepc
-          make PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc PETSC_ARCH=arch-firedrake-default
+          make PETSC_DIR=/home/runner/work/firedrakeproject.github.io/firedrakeproject.github.io/petsc PETSC_ARCH=arch-firedrake-default
           make check
           {
-            echo "PETSC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc"
+            echo "PETSC_DIR=/home/runner/work/firedrakeproject.github.io/firedrakeproject.github.io/petsc"
             echo "PETSC_ARCH=arch-firedrake-default"
-            echo "SLEPC_DIR=/__w/firedrakeproject.github.io/firedrakeproject.github.io/petsc/arch-firedrake-default"
+            echo "SLEPC_DIR=/home/runner/work/firedrakeproject.github.io/firedrakeproject.github.io/petsc/arch-firedrake-default"
           } >> "$GITHUB_ENV"
 
       - name: Install Firedrake


### PR DESCRIPTION
Still need to point to release before merging.

Also this does away with link checking here. It is only useful when running the tests and needlessly complicates the workflow.